### PR TITLE
Make use of the x86intrin.h header to add Linux support

### DIFF
--- a/fasttrigo.h
+++ b/fasttrigo.h
@@ -49,7 +49,11 @@
 #ifdef QT_GUI_LIB
 #include <QtGui>
 #endif
-#include <intrin.h>
+#ifdef _MSC_VER
+#include <intrin.h> 
+#else
+#include <x86intrin.h> 
+#endif
 #include <xmmintrin.h>
 #include <pmmintrin.h>
 


### PR DESCRIPTION
`<intrin.h>` is only available under MSVC.