### PR TITLE
Fixed `FT::atan2` and `FTA::atan2` when `x<=y`

### DIFF
--- a/fasttrigo.cpp
+++ b/fasttrigo.cpp
@@ -64,10 +64,7 @@ float FT::atan2(float y, float x)
             return y>0.f?atan+pi:atan-pi;
     } else {
         float atan=FT::atan(x/y);
-        if(x>0.f)
-            return y>0.f?halfpi-atan:-halfpi-atan;
-        else
-            return y>0.f?halfpi+atan:-halfpi+atan;
+        return y>0.f?halfpi-atan:(-halfpi)-atan;
     }
 }
 
@@ -340,10 +337,7 @@ float FTA::atan2(float y, float x)
             return y>0.f?atan+pi:atan-pi;
     } else {
         float atan=FTA::atan(x/y);
-        if(x>0.f)
-            return y>0.f?halfpi-atan:-halfpi-atan;
-        else
-            return y>0.f?halfpi+atan:-halfpi+atan;
+        return y>0.f?halfpi-atan:(-halfpi)-atan;
     }
 }
 


### PR DESCRIPTION
Before this change, `FT::atan2(0.3, -0.05)` would return 80.4648, while `std::atan2(0.3, -0.05)` returns ~99.4623, the correct result; `FTA::atan2` behaved the same way.

In order to test the accuracy of these function, I have written and used the following single-file program:

```C++
#include <iostream>

#include "fasttrigo.h"


constexpr float pi = 3.141592653589793;

constexpr float rad(float deg) { return deg * pi / 180.0f; }

constexpr float deg(float rad) { return rad * 180.0f / pi; }

constexpr float roundErr(float x) {
	constexpr float prec = 1000000.0f;
	return std::floor(x * prec) / prec;
}


int main(int, char**) {
	static constexpr size_t steps = 720*2;
	static constexpr float low = rad(-360.0f);
	static constexpr float high = rad(+360.0f);
	static constexpr float step = (high - low) / float(steps);
	for(float angle = low; angle <= high; angle += step) {
		float x = std::cos(angle) * 4.0f;
		float y = std::sin(angle) * 4.0f;
		float ftAtan2 = FT::atan2(y,x);
		float stdAtan2 = std::atan2(y,x);
		float error = std::abs(ftAtan2 - stdAtan2);
		if(error > 0.0017) std::cout << "\033[1;31m";
		std::cout
			<< "Angle " << deg(angle)
			<< "   Atan2 " << ftAtan2 << " | " << stdAtan2
			<< "   Error " << roundErr(error) << "\033[m\n";
	}
}
```